### PR TITLE
Rename AWS4AuthRequest submodule to SignatureV4

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -10,6 +10,6 @@ Currently this consists of AWS Signature v4 signing for HTTP requests sent to AW
 
 ```@docs
 AWSAuth.AWS4AuthLayer
-AWSAuth.AWS4AuthRequest.HTTP.request
-AWSAuth.AWS4AuthRequest.sign_aws4!
+AWSAuth.SignatureV4.HTTP.request
+AWSAuth.SignatureV4.sign_aws4!
 ```

--- a/src/AWSAuth.jl
+++ b/src/AWSAuth.jl
@@ -1,9 +1,9 @@
 module AWSAuth
 
-export AWS4AuthRequest, AWS4AuthLayer
+export SignatureV4, AWS4AuthLayer
 
-include("AWS4AuthRequest.jl")
+include("signaturev4.jl")
 
-using .AWS4AuthRequest
+using .SignatureV4
 
 end # module

--- a/src/signaturev4.jl
+++ b/src/signaturev4.jl
@@ -1,4 +1,4 @@
-module AWS4AuthRequest
+module SignatureV4
 
 using Base64
 using Dates

--- a/test/aws4.jl
+++ b/test/aws4.jl
@@ -1,7 +1,7 @@
 using Dates
 using Test
 using HTTP: Headers, URI
-using AWSAuth.AWS4AuthRequest: sign_aws4!
+using AWSAuth.SignatureV4: sign_aws4!
 
 # Based on https://docs.aws.amazon.com/general/latest/gr/signature-v4-test-suite.html
 # and https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html


### PR DESCRIPTION
The package's name is AWSAuth, so the context of AWS is implied, making the "AWS" prefix for the name redundant. The service itself is called Signature Version 4, so naming the module after the service is clearer.

This is the first, (hopefully) least controversial piece of a larger renaming I'd like to do here.