### PR TITLE
Correct the URLs for documentation deployment

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,7 +4,7 @@ using HTTP
 
 makedocs(modules=[AWSAuth],
          sitename="AWSAuth.jl",
-         authors="The JuliaWeb Developers",
+         authors="The JuliaCloud Developers",
          pages=["index.md"])
 
-deploydocs(repo="github.com/JuliaWeb/AWSAuth.jl.git", target="build")
+deploydocs(repo="github.com/JuliaCloud/AWSAuth.jl.git", target="build")


### PR DESCRIPTION
Forgot this in #8 